### PR TITLE
Add optional concurrency support to campaign refactor.

### DIFF
--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -260,9 +260,9 @@ class TriggerCampaignCommand extends ModeratedCommand
         $contactId    = $input->getOption('contact-id');
         $contactIds   = $this->formatterHelper->simpleCsvToArray($input->getOption('contact-ids'), 'int');
         $threadId     = $input->getOption('thread-id');
-        $threadMaxId  = $input->getOption('max-thread-id');
+        $maxThreadId  = $input->getOption('max-thread-id');
 
-        $this->limiter = new ContactLimiter($batchLimit, $contactId, $contactMinId, $contactMaxId, $contactIds, $threadId, $threadMaxId);
+        $this->limiter = new ContactLimiter($batchLimit, $contactId, $contactMinId, $contactMaxId, $contactIds, $threadId, $maxThreadId);
 
         defined('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED') or define('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED', 1);
 

--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -192,6 +192,18 @@ class TriggerCampaignCommand extends ModeratedCommand
                 null
             )
             ->addOption(
+                '--thread-id',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The number of this current process if running multiple in parallel.'
+            )
+            ->addOption(
+                '--max-thread-id',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The maximum number of processes you intend to run in parallel.'
+            )
+            ->addOption(
                 '--kickoff-only',
                 null,
                 InputOption::VALUE_NONE,
@@ -247,8 +259,10 @@ class TriggerCampaignCommand extends ModeratedCommand
         $contactMaxId = $input->getOption('max-contact-id');
         $contactId    = $input->getOption('contact-id');
         $contactIds   = $this->formatterHelper->simpleCsvToArray($input->getOption('contact-ids'), 'int');
+        $threadId     = $input->getOption('thread-id');
+        $threadMaxId  = $input->getOption('max-thread-id');
 
-        $this->limiter = new ContactLimiter($batchLimit, $contactId, $contactMinId, $contactMaxId, $contactIds);
+        $this->limiter = new ContactLimiter($batchLimit, $contactId, $contactMinId, $contactMaxId, $contactIds, $threadId, $threadMaxId);
 
         defined('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED') or define('MAUTIC_CAMPAIGN_SYSTEM_TRIGGERED', 1);
 

--- a/app/bundles/CampaignBundle/Entity/ContactLimiterTrait.php
+++ b/app/bundles/CampaignBundle/Entity/ContactLimiterTrait.php
@@ -54,6 +54,14 @@ trait ContactLimiterTrait
                 ->setParameter('maxContactId', $maxContactId);
         }
 
+        if ($threadId = $contactLimiter->getThreadId() && $threadMaxId = $contactLimiter->getThreadMaxId()) {
+            if ($threadId < $threadMaxId) {
+                $qb->andWhere("MOD(($alias.lead_id + :threadShift), :threadMax) = 0");
+                $qb->setParameter('threadShift', $threadId - 1);
+                $qb->setParameter('threadMax', $threadMaxId);
+            }
+        }
+
         if ($limit = $contactLimiter->getBatchLimit()) {
             $qb->setMaxResults($limit);
         }

--- a/app/bundles/CampaignBundle/Entity/ContactLimiterTrait.php
+++ b/app/bundles/CampaignBundle/Entity/ContactLimiterTrait.php
@@ -54,11 +54,11 @@ trait ContactLimiterTrait
                 ->setParameter('maxContactId', $maxContactId);
         }
 
-        if ($threadId = $contactLimiter->getThreadId() && $threadMaxId = $contactLimiter->getThreadMaxId()) {
-            if ($threadId < $threadMaxId) {
-                $qb->andWhere("MOD(($alias.lead_id + :threadShift), :threadMax) = 0");
-                $qb->setParameter('threadShift', $threadId - 1);
-                $qb->setParameter('threadMax', $threadMaxId);
+        if ($threadId = $contactLimiter->getThreadId() && $maxThreadId = $contactLimiter->getMaxThreadId()) {
+            if ($threadId <= $maxThreadId) {
+                $qb->andWhere("MOD(($alias.lead_id + :threadShift), :maxThreadId) = 0")
+                    ->setParameter('threadShift', $threadId - 1)
+                    ->setParameter('maxThreadId', $maxThreadId);
             }
         }
 

--- a/app/bundles/CampaignBundle/Executioner/ContactFinder/Limiter/ContactLimiter.php
+++ b/app/bundles/CampaignBundle/Executioner/ContactFinder/Limiter/ContactLimiter.php
@@ -49,6 +49,16 @@ class ContactLimiter
     private $contactIdList;
 
     /**
+     * @var int|null
+     */
+    private $threadId;
+
+    /**
+     * @var int|null
+     */
+    private $maxThreadId;
+
+    /**
      * ContactLimiter constructor.
      *
      * @param       $batchLimit
@@ -56,14 +66,25 @@ class ContactLimiter
      * @param       $minContactId
      * @param       $maxContactId
      * @param array $contactIdList
+     * @param       $threadId
+     * @param       $maxThreadId
      */
-    public function __construct($batchLimit, $contactId, $minContactId, $maxContactId, array $contactIdList = [])
-    {
+    public function __construct(
+        $batchLimit,
+        $contactId,
+        $minContactId,
+        $maxContactId,
+        array $contactIdList = [],
+        $threadId,
+        $maxThreadId
+    ) {
         $this->batchLimit    = ($batchLimit) ? (int) $batchLimit : 100;
         $this->contactId     = ($contactId) ? (int) $contactId : null;
         $this->minContactId  = ($minContactId) ? (int) $minContactId : null;
         $this->maxContactId  = ($maxContactId) ? (int) $maxContactId : null;
         $this->contactIdList = $contactIdList;
+        $this->threadId      = ($threadId) ? (int) $threadId : null;
+        $this->maxThreadId   = ($maxThreadId && $this->threadId) ? (int) $maxThreadId : null;
     }
 
     /**
@@ -129,5 +150,21 @@ class ContactLimiter
         }
 
         $this->batchMinContactId = (int) $id;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getThreadMaxId()
+    {
+        return $this->maxThreadId;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getThreadId()
+    {
+        return $this->threadId;
     }
 }

--- a/app/bundles/CampaignBundle/Executioner/ContactFinder/Limiter/ContactLimiter.php
+++ b/app/bundles/CampaignBundle/Executioner/ContactFinder/Limiter/ContactLimiter.php
@@ -155,7 +155,7 @@ class ContactLimiter
     /**
      * @return int|null
      */
-    public function getThreadMaxId()
+    public function getMaxThreadId()
     {
         return $this->maxThreadId;
     }


### PR DESCRIPTION
Needs tests.

Calling these "thread ids" because "process id" is ambiguous. Don't want to be confused with actual pids.